### PR TITLE
Convert benchmarks to use BenchmarkDotNet

### DIFF
--- a/benchmarks/LinqOptimizer.Benchmarks.CSharp/LinqOptimizer.Benchmarks.CSharp.csproj
+++ b/benchmarks/LinqOptimizer.Benchmarks.CSharp/LinqOptimizer.Benchmarks.CSharp.csproj
@@ -32,8 +32,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BenchmarkDotNet.0.9.4\lib\net40\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -48,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/benchmarks/LinqOptimizer.Benchmarks.CSharp/packages.config
+++ b/benchmarks/LinqOptimizer.Benchmarks.CSharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BenchmarkDotNet" version="0.9.4" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
Hi! 

I would like to encourage you to use [BenchmarkDotNet](https://github.com/PerfDotNet/BenchmarkDotNet) for benchmarking. This tool takes care of [all the benchmarking pitfalls](https://andreyakinshin.gitbooks.io/performancebookdotnet/content/science/microbenchmarking.html) for you.

Sample results:

   Method |            Median |         StdDev |   Scaled |   Count |
--------- |------------------ |--------------- |--------- |-------- |
 **Sum Linq** |        **15.4324 ns** |      **0.0546 ns** |     **1.00** |       **0** |
  Sum Opt |    79,807.1790 ns |  1,478.4155 ns | 5,171.40 |       0 |
 **Sum Linq** |        **80.1448 ns** |      **1.8152 ns** |     **1.00** |      **10** |
  Sum Opt |    76,826.4330 ns |    467.5502 ns |   958.60 |      10 |
 **Sum Linq** |       **657.6885 ns** |      **5.5231 ns** |     **1.00** |     **100** |
  Sum Opt |    77,090.4810 ns |    313.5956 ns |   117.21 |     100 |
 **Sum Linq** |    **59,964.2166 ns** |    **362.8734 ns** |     **1.00** |   **10000** |
  Sum Opt |    89,639.3913 ns |    672.1575 ns |     1.49 |   10000 |
 **Sum Linq** | **7,611,668.9906 ns** | **43,609.8825 ns** |     **1.00** | **1000000** |
  Sum Opt | 1,188,125.4060 ns | 50,349.8135 ns |     0.16 | 1000000 |


              Method |            Median |          StdDev |   Scaled |   Count |
-------------------- |------------------ |---------------- |--------- |-------- |
 **Sum of Squares Linq** |        **37.0205 ns** |       **0.6908 ns** |     **1.00** |       **0** |
  Sum of Squares Opt |    98,271.6938 ns |     953.2319 ns | 2,654.52 |       0 |
 **Sum of Squares Linq** |       **123.7497 ns** |       **0.9076 ns** |     **1.00** |      **10** |
  Sum of Squares Opt |    96,873.8264 ns |     598.4640 ns |   782.82 |      10 |
 **Sum of Squares Linq** |       **805.3924 ns** |       **6.5726 ns** |     **1.00** |     **100** |
  Sum of Squares Opt |    97,159.5391 ns |     273.4937 ns |   120.64 |     100 |
 **Sum of Squares Linq** |    **76,603.1563 ns** |     **547.7180 ns** |     **1.00** |   **10000** |
  Sum of Squares Opt |   108,598.5915 ns |   1,193.0457 ns |     1.42 |   10000 |
 **Sum of Squares Linq** | **9,443,594.5981 ns** | **236,979.8319 ns** |     **1.00** | **1000000** |
  Sum of Squares Opt | 1,226,722.9810 ns |  20,128.2148 ns |     0.13 | 1000000 |
